### PR TITLE
Add gh actions workflows from PLAYGROUND

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: pass-docker-services Continuous Integration
+on: [ pull_request, workflow_dispatch ]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  print-workflow-description:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+      - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+  call-workaround:
+    name: Run Parent POM Workaround
+    uses: eclipse-pass/pass-indexer/.github/workflows/parent-pom-workaround.yml@main
+  
+  call-tests-unit:
+    name: Run Unit Tests
+    uses: eclipse-pass/pass-indexer/.github/workflows/tests-unit.yml@main
+    needs: call-workaround
+    
+#  call-tests-integration:
+#    name: Run Integration Tests
+#    uses: eclipse-pass/pass-indexer/.github/workflows/tests-integration.yml@main
+#    needs: call-workaround

--- a/.github/workflows/parent-pom-workaround.yml
+++ b/.github/workflows/parent-pom-workaround.yml
@@ -1,0 +1,24 @@
+name: Parent POM Workaround
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Parent POM Workaround: Checkout pass 'main'"
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-pass/main
+      - name: "Set up JDK 14"
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: "Cache Maven packages"
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: "Parent POM Workaround: Install from pass 'main'"
+        run: mvn install --file pom.xml

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,0 +1,22 @@
+name: Run Unit Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run Integration Tests
+        run: mvn verify --file pom.xml

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -1,0 +1,22 @@
+name: Run Unit Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run Unit Tests
+        run: mvn test --file pom.xml


### PR DESCRIPTION
Issues:
- Integration tests fail (seem to go in an infinite loop -- repeated message below):

```
10:50:10.650 [main] DEBUG org.apache.activemq.util.ThreadPoolUtils - Shutdown of ExecutorService: java.util.concurrent.ThreadPoolExecutor@43195e57[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0] is shutdown: true and terminated: true took: 0.000 seconds.
10:50:10.650 [main] DEBUG org.apache.activemq.transport.tcp.TcpTransport - Stopping transport tcp://localhost:61616
10:50:10.650 [main] DEBUG org.apache.activemq.thread.TaskRunnerFactory - Initialized TaskRunnerFactory[ActiveMQ Task] using ExecutorService: java.util.concurrent.ThreadPoolExecutor@333291e3[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
10:50:10.651 [ActiveMQ Task-1] DEBUG org.apache.activemq.transport.tcp.TcpTransport - Closed socket Socket[unconnected]
10:50:10.651 [main] DEBUG org.apache.activemq.util.ThreadPoolUtils - Forcing shutdown of ExecutorService: java.util.concurrent.ThreadPoolExecutor@333291e3[Running, pool size = 1, active threads = 0, queued tasks = 0, completed tasks = 1]
10:50:10.651 [main] DEBUG org.dataconservancy.pass.indexer.JmsClient - JMS error, re-trying
javax.jms.JMSException: Could not connect to broker URL: tcp://localhost:61616. Reason: java.net.ConnectException: Connection refused (Connection refused)
	at org.apache.activemq.util.JMSExceptionSupport.create(JMSExceptionSupport.java:36)
	at org.apache.activemq.ActiveMQConnectionFactory.createActiveMQConnection(ActiveMQConnectionFactory.java:374)
	at org.apache.activemq.ActiveMQConnectionFactory.createActiveMQConnection(ActiveMQConnectionFactory.java:304)
	at org.apache.activemq.ActiveMQConnectionFactory.createConnection(ActiveMQConnectionFactory.java:244)
	at org.dataconservancy.pass.indexer.JmsClient.connect(JmsClient.java:138)
	at org.dataconservancy.pass.indexer.JmsClient.init(JmsClient.java:80)
	at org.dataconservancy.pass.indexer.JmsClient.<init>(JmsClient.java:61)
	at org.dataconservancy.pass.indexer.FedoraIndexerService.start(FedoraIndexerService.java:77)
	at org.dataconservancy.pass.indexer.PassIndexerIT.setup(PassIndexerIT.java:53)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:383)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:344)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:125)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:417)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:476)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:218)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:200)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:394)
	at java.net.Socket.connect(Socket.java:606)
	at org.apache.activemq.transport.tcp.TcpTransport.connect(TcpTransport.java:525)
	at org.apache.activemq.transport.tcp.TcpTransport.doStart(TcpTransport.java:488)
	at org.apache.activemq.util.ServiceSupport.start(ServiceSupport.java:55)
	at org.apache.activemq.transport.AbstractInactivityMonitor.start(AbstractInactivityMonitor.java:169)
	at org.apache.activemq.transport.InactivityMonitor.start(InactivityMonitor.java:52)
	at org.apache.activemq.transport.TransportFilter.start(TransportFilter.java:64)
	at org.apache.activemq.transport.WireFormatNegotiator.start(WireFormatNegotiator.java:72)
	at org.apache.activemq.transport.TransportFilter.start(TransportFilter.java:64)
	at org.apache.activemq.transport.TransportFilter.start(TransportFilter.java:64)
	at org.apache.activemq.ActiveMQConnectionFactory.createActiveMQConnection(ActiveMQConnectionFactory.java:354)
	... 25 common frames omitted
```