### PR TITLE
Comply with maven-enforcer-plugin rules about logging

### DIFF
--- a/pass-indexer-cli/pom.xml
+++ b/pass-indexer-cli/pom.xml
@@ -55,7 +55,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
     
   </dependencies>

--- a/pass-indexer-core/pom.xml
+++ b/pass-indexer-core/pom.xml
@@ -51,14 +51,12 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.unitils</groupId>
       <artifactId>unitils-core</artifactId>
-      <version>3.4.2</version>
       <scope>test</scope>
     </dependency>
 
@@ -99,7 +97,6 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pass-indexer-core/pom.xml
+++ b/pass-indexer-core/pom.xml
@@ -55,6 +55,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.unitils</groupId>
       <artifactId>unitils-core</artifactId>
       <scope>test</scope>

--- a/pass-indexer-reindex-cli/pom.xml
+++ b/pass-indexer-reindex-cli/pom.xml
@@ -92,7 +92,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
     
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <okhttp.version>3.10.0</okhttp.version>
     <openpojo.version>0.8.10</openpojo.version>
     <pass.client.version>0.6.0</pass.client.version>
+    <unitils.version>3.4.2</unitils.version>
   </properties>
 
   <build>
@@ -77,6 +78,36 @@
         <groupId>org.dataconservancy.pass</groupId>
         <artifactId>pass-indexer-core</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.unitils</groupId>
+        <artifactId>unitils-core</artifactId>
+        <version>${unitils.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Relates to https://github.com/eclipse-pass/main/issues/240

* Move logging focused dependencies into project's top level POM
* Move some version declarations to the top level POM (out of sub-module POMs)

## Note
I was unable to get the ITs to run, ~unit tests did pass~. Curiously, unit tests failed the first time, then passed on the second run with no changes.

This also required the parent POM from https://github.com/eclipse-pass/main/pull/258 to be installed locally before the `maven-enforcer-plugin` is automatically run in the project.